### PR TITLE
Update build process to use git commit hash

### DIFF
--- a/.github/workflows/testandbuild.yml
+++ b/.github/workflows/testandbuild.yml
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build latest
-        run: docker build . --tag wedotakeaway/wdt-server:${env.GIT_COMMIT}
+        run: docker build . --tag wedotakeaway/wdt-server:${env.GITHUB_SHA}
 
   dockerPush:
     name: Docker Push
@@ -200,7 +200,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build latest
-        run: docker build . --tag wedotakeaway/wdt-server:${env.GIT_COMMIT}
+        run: docker build . --tag wedotakeaway/wdt-server:${env.GITHUB_SHA}
 
       - name: Push latest
-        run: docker push wedotakeaway/wdt-server:${env.GIT_COMMIT}
+        run: docker push wedotakeaway/wdt-server:${env.GITHUB_SHA}

--- a/.github/workflows/testandbuild.yml
+++ b/.github/workflows/testandbuild.yml
@@ -177,18 +177,23 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-latest
     needs: sonar-cloud
+    env:
+      SHA8: ${GITHUB_SHA::8}
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Build latest
-        run: docker build . --tag wedotakeaway/wdt-server:${env.GITHUB_SHA}
+        run: docker build . --tag wedotakeaway/wdt-server:$SHA8
 
   dockerPush:
     name: Docker Push
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: dockerBuild
+    env:
+      SHA8: ${GITHUB_SHA::8}
+
 
     steps:
       - uses: actions/checkout@v2
@@ -200,7 +205,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build latest
-        run: docker build . --tag wedotakeaway/wdt-server:${env.GITHUB_SHA}
+        run: docker build . --tag wedotakeaway/wdt-server:$SHA8
 
       - name: Push latest
-        run: docker push wedotakeaway/wdt-server:${env.GITHUB_SHA}
+        run: docker push wedotakeaway/wdt-server:$SHA8

--- a/.github/workflows/testandbuild.yml
+++ b/.github/workflows/testandbuild.yml
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build latest
-        run: docker build . --tag wedotakeaway/wdt-server:latest
+        run: docker build . --tag wedotakeaway/wdt-server:${env.GIT_COMMIT}
 
   dockerPush:
     name: Docker Push
@@ -200,7 +200,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build latest
-        run: docker build . --tag wedotakeaway/wdt-server:latest
+        run: docker build . --tag wedotakeaway/wdt-server:${env.GIT_COMMIT}
 
       - name: Push latest
-        run: docker push wedotakeaway/wdt-server:latest
+        run: docker push wedotakeaway/wdt-server:${env.GIT_COMMIT}


### PR DESCRIPTION
Using a hash provides a unique id for an image and allows easier integration down the line with K8's and the like that need a unique id to force downloading a new image